### PR TITLE
:sparkles:feat ログアウト機能を実装しました

### DIFF
--- a/api/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/api/app/controllers/api/v1/auth/registrations_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsCon
   private
 
   def sign_up_params
-    params.permit(:email, :password, :password_confirmation, :name)
+    params.require(:registration).permit(:email, :password, :password_confirmation, :name)
   end
 
   def set_token_info

--- a/api/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/api/app/controllers/api/v1/auth/sessions_controller.rb
@@ -1,0 +1,9 @@
+class Api::V1::Auth::SessionsController < DeviseTokenAuth::SessionsController
+  def index
+    if current_api_v1_user
+      render json: { is_login: true, data: current_api_v1_user }
+    else
+      render json: { is_login: false, message: "ユーザーが存在しません" }
+    end
+  end
+end

--- a/api/config/application.rb
+++ b/api/config/application.rb
@@ -15,5 +15,8 @@ module Api
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local
     config.i18n.default_locale = :ja
+    config.session_store :cookie_store, key: '_your_app_session'
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use ActionDispatch::Session::CookieStore, config.session_options
   end
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -4,6 +4,9 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for 'User', at: 'auth', controllers: {
         registrations: 'api/v1/auth/registrations'
       }
+      namespace :auth do
+        resources :sessions, only: %i[index]
+      end
     end
   end
 end

--- a/api/test/controllers/api/v1/auth/registrations_controller_test.rb
+++ b/api/test/controllers/api/v1/auth/registrations_controller_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class Api::V1::Auth::RegistrationsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/front/src/components/Layouts/Header.tsx
+++ b/front/src/components/Layouts/Header.tsx
@@ -1,12 +1,21 @@
 import React, { useState } from 'react'
 import Link from 'next/link'
 import { AiOutlineMenu, AiOutlineClose } from 'react-icons/ai';
+import useSignout from '../../hooks/useSignout';
+
 
 
 export default function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const signout = useSignout(); 
 
   const toggleMenu = () => setIsMenuOpen(!isMenuOpen);
+
+  const handleSignout = (e) => {
+    e.preventDefault(); // デフォルトのリンク動作を防止
+    signout();
+  };
+
 
   return (
     <header className="container py-4">
@@ -21,7 +30,7 @@ export default function Header() {
         {isMenuOpen && (
           <div className="absolute right-0 mt-5 py-2 w-48 bg-white rounded-lg shadow-xl">
             <Link href="/profile" className="block px-4 py-2 hover:bg-gray-200">プロフィール</Link>
-            <Link href="/logout" className="block px-4 py-2 hover:bg-gray-200">ログアウト</Link>
+            <button onClick={handleSignout} className="block px-4 py-2 hover:bg-gray-200 text-left w-full">ログアウト</button>
           </div>
         )}
       </div>

--- a/front/src/hooks/useSignout.js
+++ b/front/src/hooks/useSignout.js
@@ -1,0 +1,35 @@
+import { useRouter } from 'next/navigation';
+import Cookies from 'js-cookie';
+import axios from 'axios';
+
+export default function useSignout() {
+  const router = useRouter();
+
+  const signout = async () => {
+    try {
+      const accessToken = Cookies.get('access-token');
+      const client = Cookies.get('client');
+      const uid = Cookies.get('uid');
+
+      const config = {
+        headers: {
+          'access-token': accessToken,
+          'client': client,
+          'uid': uid,
+        }
+      };
+
+      await axios.delete('http://localhost:3001/api/v1/auth/sign_out', config);
+
+      Cookies.remove('access-token');
+      Cookies.remove('client');
+      Cookies.remove('uid');
+
+      router.push('/');
+    } catch (error) {
+      console.error('サインアウト時にエラーが発生しました:', error);
+    }
+  };
+
+  return signout;
+};


### PR DESCRIPTION
## 概要
ログイン後home画面から、headerのログアウトを押すとcookieが削除されtop画面に遷移する

## 問題点
新規登録時に送信されるPOSTリクエストのペイロードがネストされた構造になっています。
具体的には、name、email、password、password_confirmationがregistrationキーの下にグループ化されています。
[![Image from Gyazo](https://i.gyazo.com/25942969e3413c68e916ef4f86d31fc3.png)](https://gyazo.com/25942969e3413c68e916ef4f86d31fc3)

この形式により、バックエンド側でのパラメータ受け取りに問題が発生しています。
そのため、ストロングパラーメーターの引数を意図的にネストさせた状態に設定しました。
```
    params.require(:registration).permit(:email, :password, :password_confirmation, :name)
```
原因は調査中です。

