### PR TITLE
:sparkles:feat 選択した月に対応した一覧が表示されるように変更しました

### DIFF
--- a/api/app/controllers/api/v1/logs_controller.rb
+++ b/api/app/controllers/api/v1/logs_controller.rb
@@ -2,7 +2,19 @@ class Api::V1::LogsController < ApplicationController
   before_action :authenticate_api_v1_user! 
 
   def index
-    logs = current_api_v1_user.logs.includes(:action).order(date: :desc)
+    year = params[:year]
+    month = params[:month]
+    
+    if year && month
+      start_date = Date.new(year.to_i, month.to_i, 1)
+      end_date = start_date.end_of_month
+      logs = current_api_v1_user.logs.where(date: start_date..end_date)
+    else
+      logs = current_api_v1_user.logs
+    end
+    
+    logs = logs.includes(:action).order(date: :desc)
+    Rails.logger.debug "Sending logs to front-end: #{logs.as_json(include: :action)}"
     render json: logs.as_json(include: :action)
   end
   
@@ -21,6 +33,6 @@ class Api::V1::LogsController < ApplicationController
   private
 
   def log_params
-    params.require(:log).permit(:date, :note, :name)
+    params.require(:log).permit(:date, :note, :name, :year, :month)
   end
 end

--- a/front/src/app/home/components/button/CreateButton.tsx
+++ b/front/src/app/home/components/button/CreateButton.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 export default function CreateButton() {
   return (
     <>
-      <button type="button" className="w-12 h-12 flex justify-center items-center gap-x-2 text-3xl font-semibold rounded-full border border-transparent bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 disabled:pointer-events-none dark:focus:outline-none dark:focus:ring-1 dark:focus:ring-gray-600">
+      <button type="button" className="w-12 h-12 flex justify-center items-center gap-x-2 text-3xl font-semibold rounded-full border border-transparent bg-custom-pink text-white hover:bg-custom-dark-pink disabled:opacity-50 disabled:pointer-events-none dark:focus:outline-none dark:focus:ring-1 dark:focus:ring-gray-600">
         ＋
       </button>
     </>

--- a/front/src/app/home/components/button/MonthSelector.jsx
+++ b/front/src/app/home/components/button/MonthSelector.jsx
@@ -1,6 +1,4 @@
-import { useState } from 'react';
-
-export default function MonthSelector({ onMonthSelect }) {
+export default function MonthSelector({ selectedMonth, onMonthSelect }) {
   return (
     <div className="container flex overflow-x-auto py-2 space-x-2">
       <div className="flex gap-6">
@@ -8,7 +6,7 @@ export default function MonthSelector({ onMonthSelect }) {
           <div
             key={i}
             onClick={() => onMonthSelect(i + 1)}
-            className="w-auto flex-none h-12 flex items-center justify-center text-lg cursor-pointer select-none"
+            className={`w-auto flex-none h-12 flex items-center justify-center text-lg cursor-pointer select-none ${selectedMonth === i + 1 ? "border-b-2 border-custom-pink text-custom-pink" : ""}`}
             style={{ minWidth: 'calc((100% - 4rem) / 6)' }}
           >
             {i + 1}
@@ -18,5 +16,3 @@ export default function MonthSelector({ onMonthSelect }) {
     </div>
   );
 }
-
-

--- a/front/src/app/home/components/button/MonthSelector.jsx
+++ b/front/src/app/home/components/button/MonthSelector.jsx
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+
+export default function MonthSelector({ onMonthSelect }) {
+  return (
+    <div className="container flex overflow-x-auto py-2 space-x-2">
+      <div className="flex gap-6">
+        {Array.from({ length: 12 }, (_, i) => (
+          <div
+            key={i}
+            onClick={() => onMonthSelect(i + 1)}
+            className="w-auto flex-none h-12 flex items-center justify-center text-lg cursor-pointer select-none"
+            style={{ minWidth: 'calc((100% - 4rem) / 6)' }}
+          >
+            {i + 1}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+

--- a/front/src/app/home/components/index/logIndex.jsx
+++ b/front/src/app/home/components/index/logIndex.jsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import axios from 'axios';
 import Cookies from 'js-cookie';
-import LogItem from '@/home/components/items/logItem'
+import LogItem from '@/home/components/items/logItem';
 
-export default function LogIndex() {
+// selectedMonthをpropsとして受け取る
+export default function LogIndex({ selectedMonth }) {
   const [logs, setLogs] = useState([]);
 
   const accessToken = Cookies.get('access-token');
@@ -11,24 +12,34 @@ export default function LogIndex() {
   const uid = Cookies.get('uid');
 
   useEffect(() => {
-    axios.get('http://localhost:3001/api/v1/logs', {
-      headers: {
-        'access-token': accessToken,
-        'client': client,
-        'uid': uid
-      },
-    })
-    .then(response => {
-      setLogs(response.data);
-    })
-    .catch(error => console.error('Error:', error));
-  }, []);
+    // selectedMonthがnullでない場合にのみAPIリクエストを行う
+    if (selectedMonth !== null) {
+      const year = new Date().getFullYear(); // 現在の年を取得
+      axios.get('http://localhost:3001/api/v1/logs', {
+        params: { year, month: selectedMonth },
+        headers: {
+          'access-token': accessToken,
+          'client': client,
+          'uid': uid
+        },
+      })
+      .then(response => {
+        console.log(response.data);
+        setLogs(response.data); // 取得したログデータでステートを更新
+      })
+      .catch(error => console.error('Error:', error));
+    }
+  }, [selectedMonth]); // selectedMonthが変更されるたびに効果を再実行
 
   return (
     <div>
-      {logs.map(log => (
-        <LogItem key={log.id} log={log} /> 
-      ))}
+      {logs.length > 0 ? (
+        logs.map(log => (
+          <LogItem key={log.id} log={log} />
+        ))
+      ) : (
+        <p className="text-center mt-7">この月は投稿がありません</p> // ログがない場合の表示
+      )}
     </div>
   );
 }

--- a/front/src/app/home/components/items/logItem.jsx
+++ b/front/src/app/home/components/items/logItem.jsx
@@ -5,11 +5,11 @@ export default function LogItem({ log }) {
   const day = date.toLocaleDateString('ja-JP', { day: 'numeric' });
   return (
     <div className="container">
-    <div className="flex items-center text-cen bg-gray-200 p-4 my-4 mb-2 rounded-lg">
-      <p className="flex-1 text-sm md:text-base">{day}</p>
-      <p className="flex-1 text-sm md:text-base">{log.action.name}</p>
-      <p className="flex-1 text-sm md:text-base">{log.note}</p>
-    </div>
+      <div className="flex items-center text-cen bg-gray-200 p-4 my-4 mb-2 rounded-lg">
+        <p className="flex-1 text-sm md:text-base">{day}</p>
+        <p className="flex-1 text-sm md:text-base">{log.action.name}</p>
+        <p className="flex-1 text-sm md:text-base">{log.note}</p>
+      </div>
     </div>
   );
 }

--- a/front/src/app/home/components/items/logItem.jsx
+++ b/front/src/app/home/components/items/logItem.jsx
@@ -1,9 +1,15 @@
 export default function LogItem({ log }) {
+  // Date オブジェクトを作成
+  const date = new Date(log.date);
+  // 日にちだけを抽出
+  const day = date.toLocaleDateString('ja-JP', { day: 'numeric' });
   return (
+    <div className="container">
     <div className="flex items-center text-cen bg-gray-200 p-4 my-4 mb-2 rounded-lg">
-      <p className="flex-1 text-sm md:text-base">{log.date}</p>
+      <p className="flex-1 text-sm md:text-base">{day}</p>
       <p className="flex-1 text-sm md:text-base">{log.action.name}</p>
       <p className="flex-1 text-sm md:text-base">{log.note}</p>
+    </div>
     </div>
   );
 }

--- a/front/src/app/home/page.jsx
+++ b/front/src/app/home/page.jsx
@@ -1,15 +1,23 @@
 "use client";
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Header from '@/components/Layouts/Header';
 import Footer from '@/components/Layouts/Footer';
-import HomeImage from '@/home/components/images/homeimage'
+import HomeImage from '@/home/components/images/homeimage';
 import MonthSelector from '@/home/components/button/MonthSelector';
 import CreateButton from '@/home/components/button/CreateButton';
 import LogIndex from '@/home/components/index/logIndex';
 import Link from 'next/link'; 
 
 export default function Home() {
-  const [selectedMonth, setSelectedMonth] = useState(null);
+  const currentMonth = new Date().getMonth() + 1; // JavaScriptの月は0から始まるため+1する
+  const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
+  const [selectedMonth, setSelectedMonth] = useState(currentMonth);
+  const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+
+  useEffect(() => {
+    // MonthSelectorに現在の月を初期値として設定する
+    handleMonthSelect(currentMonth);
+  }, []); // 空の依存配列でコンポーネントマウント時のみ実行
 
   const handleMonthSelect = (month) => {
     console.log(`${month}月が選択されました。`); // 選択された月をコンソールに表示
@@ -21,17 +29,23 @@ export default function Home() {
       <div className="fixed top-0 left-0 w-full z-10">
         <Header />
       </div>
-      <div className="pt-[120px]">
-        <HomeImage />
+      <div className='relative'>
+        <div className="pt-[120px]">
+          <HomeImage />
+        </div>
+        <div className='absolute top-40 ml-4 mt-4 text-white text-left'>
+          <div className='text-l'>{selectedYear}</div>
+          <div className="text-3xl">{selectedMonth && months[selectedMonth - 1]}</div>
+        </div>
       </div>
-      <MonthSelector onMonthSelect={handleMonthSelect} />
+      <MonthSelector selectedMonth={selectedMonth} onMonthSelect={handleMonthSelect} />
       <div className="fixed right-5 bottom-5 z-50">
         <Link href="/log/new" passHref>
           <CreateButton />
         </Link>
       </div>
       <LogIndex selectedMonth={selectedMonth}/>
-      {/* ここにindexページのその他のコンテンツを追加 */}
+      {/* その他のコンテンツ */}
       <div>
         <Footer />
       </div>

--- a/front/src/app/home/page.jsx
+++ b/front/src/app/home/page.jsx
@@ -1,12 +1,21 @@
 "use client";
+import { useState } from 'react';
 import Header from '@/components/Layouts/Header';
 import Footer from '@/components/Layouts/Footer';
 import HomeImage from '@/home/components/images/homeimage'
+import MonthSelector from '@/home/components/button/MonthSelector';
 import CreateButton from '@/home/components/button/CreateButton';
-import LogIndex from '@/home/components/index/logindex';
+import LogIndex from '@/home/components/index/logIndex';
 import Link from 'next/link'; 
 
 export default function Home() {
+  const [selectedMonth, setSelectedMonth] = useState(null);
+
+  const handleMonthSelect = (month) => {
+    console.log(`${month}月が選択されました。`); // 選択された月をコンソールに表示
+    setSelectedMonth(month); // 選択された月でステートを更新
+  };
+
   return (
     <>
       <div className="fixed top-0 left-0 w-full z-10">
@@ -15,12 +24,13 @@ export default function Home() {
       <div className="pt-[120px]">
         <HomeImage />
       </div>
+      <MonthSelector onMonthSelect={handleMonthSelect} />
       <div className="fixed right-5 bottom-5 z-50">
         <Link href="/log/new" passHref>
           <CreateButton />
         </Link>
       </div>
-      <LogIndex />
+      <LogIndex selectedMonth={selectedMonth}/>
       {/* ここにindexページのその他のコンテンツを追加 */}
       <div>
         <Footer />

--- a/front/src/app/log/new/page.jsx
+++ b/front/src/app/log/new/page.jsx
@@ -39,7 +39,7 @@ export default function LogForm() {
             />
             <button
               type="submit"
-              className="w-full py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-500 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+              className="w-full py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-custom-pink hover:bg-custom-dark-pink focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
             >投稿
             </button>
           </form>

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -32,7 +32,7 @@ export default function Home() {
           <p className="text-xl text-white">早速お世話の記録をつけてみましょう！</p>
         </div>
         <div className="space-y-4">
-          <button onClick={openSignupModal} className="w-full py-3 px-4 inline-flex justify-center items-center gap-x-2 text-sm font-semibold rounded-lg border border-transparent bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 disabled:pointer-events-none dark:focus:outline-none dark:focus:ring-1 dark:focus:ring-gray-600">
+          <button onClick={openSignupModal} className="w-full py-3 px-4 inline-flex justify-center items-center gap-x-2 text-sm font-semibold rounded-lg border border-transparent bg-custom-pink text-white hover:bg-custom-dark-pink disabled:opacity-50 disabled:pointer-events-none dark:focus:outline-none dark:focus:ring-1 dark:focus:ring-gray-600">
             新規登録
           </button>
           {showModal === "signup" && (

--- a/front/src/auth/signin/SigninForm.jsx
+++ b/front/src/auth/signin/SigninForm.jsx
@@ -42,7 +42,7 @@ export default function SigninForm({ onClose }) {
             />
             <button
               type="submit"
-              className="w-full py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-500 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+              className="w-full py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-custom-pink hover:bg-custom-dark-pink focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-custom-pink"
               disabled={isLoading}
             >
               {isLoading ? 'ログイン中...' : 'ログイン'}

--- a/front/src/auth/signup/SignupForm.jsx
+++ b/front/src/auth/signup/SignupForm.jsx
@@ -51,7 +51,7 @@ export default function SignupForm({ onClose }) {
             />
             <button
               type="submit"
-              className="w-full py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-500 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+              className="w-full py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-custom-pink hover:bg-custom-dark-pink focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
               disabled={isLoading}
             >
               {isLoading ? '登録中...' : '登録'}

--- a/front/tailwind.config.ts
+++ b/front/tailwind.config.ts
@@ -9,13 +9,18 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      colors: {
+        'custom-pink': '#FF469F', // Custom color added
+        'custom-dark-pink': '#B73162',
+        'custom-right-pink': '#E389BA'
+      },
       backgroundImage: {
         "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
-        "gradient-conic":
-          "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
+        "gradient-conic": "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
       },
     },
   },
   plugins: [],
 };
+
 export default config;


### PR DESCRIPTION
## issue
close #29 #30 #31 #32 

## 概要
monthSelectorコンポーネントを作成し、数字をクリックするとその月に投稿した一覧のみ表示されるようにしました。
セレクトバーは横にスクロールすることで全体を見ることができます。
デフォルトでは現在の月が最初に表示されます。
選択した月の数字の色を変更、アンダーバーの表示をすることでわかりやすくしました。

## image
[![Image from Gyazo](https://i.gyazo.com/ef9e36d24abe8b8a71c223f934b1bcf6.png)](https://gyazo.com/ef9e36d24abe8b8a71c223f934b1bcf6)
[![Image from Gyazo](https://i.gyazo.com/e3a26b3ed42fcd5dfd3ff2f3f0f7dd96.png)](https://gyazo.com/e3a26b3ed42fcd5dfd3ff2f3f0f7dd96)

## 課題

- monthSelectorコンポーネントで表示されている数字が2024-01~12までの表示しかできていない為、2023年以前の投稿を閲覧できない。
修正案：home画面が開いた段階ですべてのlogデータを獲得し一番最初の投稿がある年月から、現在の月までの数字を表示させるようにする。また現在は月を切り替えるごとにSQLが発行されているので、homeを表示した段階、またはコンテンツ（日記、Log、レポート、カレンダー）を表示した段階でSQLを発行保持し、表示させる範囲の切り替えをフロントのみで行うよう変更する。

- imagecolorをblueからcustom-pinkに変更したが、男性には使いにくい色合いかもしれない。ターゲットは女性の割合が多いが、男性のほうが記録を豆につける人が多いイメージがある。今後どのような配慮を加えるか検討する必要がある。
修正案：イメージカラーを変更できるよう、カラーサンプルを数パターン用意し、オプションで変更できるといいかもしれない。そのためには、tailwindcssで直接書き込んでいる部分をスタイルコンポーネントにかき分ける必要がある。


