### PR TITLE
fly再デプロイ

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -10,8 +10,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Prepare deployment
+        run: |
+          cp fly.yml api/
       - name: Deploy to Fly.io
-        run: flyctl deploy --remote-only
-        working-directory: ./api
+        run: |
+          cd api
+          flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## 概要
GitActionsがプロジェクトディレクトリを参照しているため、fly.ymlをPGディレクトリに移動
fly.ymlをapiディレクトリにコピーしてからデプロイする記述を追加